### PR TITLE
Fix offset increment in append.

### DIFF
--- a/src/niffs_internal.c
+++ b/src/niffs_internal.c
@@ -755,7 +755,7 @@ int niffs_append(niffs *fs, int fd_ix, u8_t *src, u32_t len) {
     src += avail;
     data_offs += avail;
     written += avail;
-    fd->offs += written;
+    fd->offs += avail;
   }
 
   _NIFFS_ERR_FREE_RETURN(fs, orig_ohdr, res);


### PR DESCRIPTION
Fix an issue in file append where the offset in the file descriptor was incremented by an already accumulated value which breaks consecutive append operations.
